### PR TITLE
feat: add shape shifter compatibility

### DIFF
--- a/assets/styles/epub/_fonts.scss
+++ b/assets/styles/epub/_fonts.scss
@@ -1,17 +1,30 @@
 @import 'font-stack-epub'; // Dynamically generated
 
+$serif-epub: serif !default;
 $sans-serif-epub: sans-serif !default;
+
+// Load Shape Shifter fonts, if any. Must come after Global Typography snippet
+@import 'shapeshifter-font-stack-epub';
+
+$shapeshifter-font-1-is-serif: true !default;
+$shapeshifter-font-2-is-serif: true !default;
 
 // Insert custom fonts for your theme into the font stacks below. Always end the
 // stack with $serif-epub or $sans-serif-epub, as appropriate—this allows custom
 // language support to be added dynamically.
-$font-1: 'Montserrat', $sans-serif-epub;
-$font-2: 'Montserrat', $sans-serif-epub;
-$font-3: $font-2;
 
-// Add import rules for any fonts you referenced below. Available font partials
-// are found in /pressbooks/assets/scss/fonts and follow the naming pattern:
-// _FontNameInCamelCaseFont.scss. For example, to import Alegreya Sans, use:
-// @import 'AlegreyaSansFont';
+@if variable-exists(shapeshifter-font-1) {
+  $font-1: $shapeshifter-font-1, if($shapeshifter-font-1-is-serif, $serif-epub, $sans-serif-epub);
+} @else {
+  $font-1: 'Montserrat', $sans-serif-epub;
+}
+
+@if variable-exists(shapeshifter-font-2) {
+  $font-2: $shapeshifter-font-2, if($shapeshifter-font-2-is-serif, $serif-epub, $sans-serif-epub);
+} @else {
+  $font-2: 'Montserrat', $sans-serif-epub;
+}
+
+$font-3: $font-2;
 
 @import 'MontserratFont';

--- a/assets/styles/prince/_fonts.scss
+++ b/assets/styles/prince/_fonts.scss
@@ -1,17 +1,30 @@
 @import 'font-stack-prince'; // Dynamically generated
 
+$serif-prince: serif !default;
 $sans-serif-prince: sans-serif !default;
+
+// Load Shape Shifter fonts, if any. Must come after Global Typography snippet
+@import 'shapeshifter-font-stack-prince';
+
+$shapeshifter-font-1-is-serif: true !default;
+$shapeshifter-font-2-is-serif: true !default;
 
 // Insert custom fonts for your theme into the font stacks below. Always end the
 // stack with $serif-prince or $sans-serif-prince, as appropriate—this allows
 // custom language support to be added dynamically.
-$font-1: 'Montserrat', $sans-serif-prince;
-$font-2: 'Montserrat', $sans-serif-prince;
-$font-3: $font-2;
 
-// Add import rules for any fonts you referenced below. Available font partials
-// are found in /pressbooks/assets/scss/fonts and follow the naming pattern:
-// _FontNameInCamelCaseFont.scss. For example, to import Alegreya Sans, use:
-// @import 'AlegreyaSansFont';
+@if variable-exists(shapeshifter-font-1)  {
+  $font-1: $shapeshifter-font-1, if($shapeshifter-font-1-is-serif, $serif-prince, $sans-serif-prince);
+} @else {
+  $font-1: 'Montserrat', $sans-serif-prince;
+}
+
+@if variable-exists(shapeshifter-font-2) {
+  $font-2: $shapeshifter-font-2, if($shapeshifter-font-2-is-serif, $serif-prince, $sans-serif-prince);
+} @else {
+  $font-2: 'Montserrat', $sans-serif-prince;
+}
+
+$font-3: $font-2;
 
 @import 'MontserratFont';

--- a/assets/styles/web/_fonts.scss
+++ b/assets/styles/web/_fonts.scss
@@ -1,15 +1,30 @@
 @import 'font-stack-web'; // Dynamically generated
 
+$serif-web: serif !default;
 $sans-serif-web: sans-serif !default;
+
+// Load Shape Shifter fonts, if any. Must come after Global Typography snippet
+@import 'shapeshifter-font-stack-web';
+
+$shapeshifter-font-1-is-serif: true !default;
+$shapeshifter-font-2-is-serif: true !default;
 
 // Insert custom fonts for your theme into the font stacks below. Always end the
 // stack with $serif-web or $sans-serif-web, as appropriate—this allows custom
 // language support to be added dynamically.
-$font-1: 'Montserrat', $sans-serif-web;
-$font-2: 'Montserrat', $sans-serif-web;
+
+@if variable-exists(shapeshifter-font-1) {
+  $font-1: $shapeshifter-font-1, if($shapeshifter-font-1-is-serif, $serif-web, $sans-serif-web);
+} @else {
+  $font-1: 'Montserrat', $sans-serif-web;
+}
+
+@if variable-exists(shapeshifter-font-2) {
+  $font-2: $shapeshifter-font-2, if($shapeshifter-font-2-is-serif, $serif-web, $sans-serif-web);
+} @else {
+  $font-2: 'Montserrat', $sans-serif-web;
+}
+
 $font-3: $font-2;
 
-// Add import rules for any referenced fonts you below. You must use Google
-// Fonts or an equivalent over https. For example, to import Alegreya Sans, use:
-// @import 'https://fonts.googleapis.com/css?family=Alegreya+Sans';
 @import 'https://fonts.googleapis.com/css?family=Montserrat:400,400i,600,600i';

--- a/functions.php
+++ b/functions.php
@@ -4,6 +4,4 @@
  * @license GPLv2 (or any later version)
  */
 
-add_action( 'after_setup_theme', function () {
-	// TODO
-} );
+add_filter( 'pb_is_shape_shifter_compatible', '__return_true' );


### PR DESCRIPTION
Issue pressbooks/ideas#431

This PR adds compatibility with the shape shifter feature allowing users to change the typography of the theme.

**How to test**

1. Enable Jacobs theme in **Appearance > Themes**
2. Visit the book's page and the theme should be applied normally without changes
3. Visit **Appearance > Theme Options** and change the font for Web, PDF, and EPUB
4. Visit the book's page once more and validate the font was modified accordingly
5. Generate PDF/EPUB exports and make sure changes are reflected in the exports as well